### PR TITLE
Fix incorrect argument passed to array_sort

### DIFF
--- a/scripts/ElephantWrite/ElephantWrite.gml
+++ b/scripts/ElephantWrite/ElephantWrite.gml
@@ -250,7 +250,7 @@ function __ElephantBufferInner(_buffer, _target, _datatype)
                 else
                 {
                     //Alphabetize the variables names so that they'll match the order that they will be deserialized
-                    array_sort(_names, lb_sort_ascending);
+                    array_sort(_names, true);
             
                     //Iterate over the serializable variable names and write them
                     var _i = 0;


### PR DESCRIPTION
`array_sort` in ElephantWrite was using `lb_sort_ascending` as its second argument, which is meant for steam leaderboards, not the array sorting function. This function expects either a bool value or a custom sort function. In gamemaker v2022 at least this causes a runtime error when the function is called (maybe this still seemed to work pre-v2022, not sure).

I just changed the argument to properly use `true` when sorting by ascending and it seeems to fix this error. I don't know if this needs to be fixed in other places in the code as well, as this was the only part causing me errors.